### PR TITLE
[PR] 뒤로가기 스크롤 에러수정

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/client/src/pages/Search.jsx
+++ b/client/src/pages/Search.jsx
@@ -63,7 +63,7 @@ function Search() {
       // 그게 아니라면 초기화
       onObserver(false);
       dispatch(setProductList([], 0));
-      setPageTotal(1);
+      setPageTotal(2);
       setQueryPage(1);
       setSearchOrder('views');
     }
@@ -79,7 +79,7 @@ function Search() {
       query = parsedQuery.query;
       type = parsedQuery.type;
       dispatch(setProductList([], 0));
-      setPageTotal(1);
+      setPageTotal(2);
       if (queryPage === 1) {
         // eslint-disable-next-line no-use-before-define
         getMoreProducts();

--- a/server/models/product.js
+++ b/server/models/product.js
@@ -62,7 +62,7 @@ module.exports = (sequelize, DataTypes) => {
       updatedAt: false,
       indexes: [
         {
-          fields: ['views', 'reviewCount', 'id'],
+          fields: ['views', 'reviewsCount', 'id'],
         },
         {
           fields: ['reviewsCount', 'views', 'id'],


### PR DESCRIPTION
PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트


서치페이치에서 마이페이지로 갔다가 다시 뒤로가기로 돌아오면 스크롤이 되지 않는 현상 수정.
page가 변할때마다 히스토리 상태에 현재페이지와 전체 페이지를 담는데 페이지가 바뀌고 서버와 통신을 해야 전체 페이지를 알기 때문에 그 전까지는 전체페이지를 2페이지로 초기화해서 서버에 1번은 요청하게 해야함.

근데 일부 초기화과정에서 전체페이지를 1로 초기화해서 쭉 스크롤 할땐 서버에서 받아 온 전체페이지가 히스토리에 저장되어 상관없지만, 추가 로딩안하고 다른 페이지 갔다가 뒤로가기 했을 때는 페이지가 끝난 걸로 판단돼서 더 이상 로딩이 되지 않음.

모든 초기화과정에서 전체페이지 2로 초기화


테스트 결과
ex) 현재까지 문제 없습니다.