### PR TITLE
[PR] 검색결과 없을때 페이지네이션 표시 오류 수정 및 페이지네이션 css 너비 수정

### DIFF
--- a/client/src/pages/Search.jsx
+++ b/client/src/pages/Search.jsx
@@ -79,7 +79,7 @@ function Search() {
       addProductList(
         response.data.items,
         response.data.pages.itemCount,
-        response.data.pages.total,
+        response.data.pages.total === 0 ? 1 : response.data.pages.total,
       ),
     );
   };

--- a/client/src/styles/search/SearchPageButtons.scss
+++ b/client/src/styles/search/SearchPageButtons.scss
@@ -1,9 +1,7 @@
 @import '../../App.scss';
 
 .pageBtnContainer {
-  // min-width: 375px;
-  width: 88%;
-  max-width: 300px;
+  min-width: 300px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -17,6 +15,7 @@
     justify-content: center;
     align-items: center;
     text-align: center;
+    position: relative;
 
     .pageNum {
       width: 100%;
@@ -42,9 +41,7 @@
     .currentPage {
       width: 100%;
       color: $deep-blue;
-      // background-color: $deep-blue;
       border-radius: 4px;
-      // padding: 4px;
       font-size: 2rem;
       font-weight: 800;
     }
@@ -56,23 +53,24 @@
 
 @include tablet {
   .pageBtnContainer {
-    width: 70%;
-    max-width: none;
     .none {
       display: block;
-      width: 45px;
+      width: 55px;
       height: 40px;
       text-align: center;
       display: flex;
       justify-content: center;
       align-items: center;
       text-align: center;
+      .pageNum {
+        width: 100%;
+      }
     }
     .pageBtn,
     .selected {
       .prev,
       .next {
-        width: 60%;
+        width: 40%;
       }
       .currentPage {
         color: $white;
@@ -91,6 +89,7 @@
     .pageBtn,
     .selected,
     .none {
+      width: 60px;
       .pageNum,
       .currentPage {
         font-size: 1.6rem;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev -> dev

### 변경 사항
1. 검색결과없을때 페이지네이션표시오류 수정 
   -> 서버에서 결과 없을때, 응답의 total:0 으로 오기때문에 0일 경우, 1로 저장하도록 수정
2. 페이지네이션 css 너비 수정
  - 페이지 수가 적을 때  페이지가 많을 때 만큼 너비가 넓어서 보기 좋지 않음
  -> 전체 너비로 조정하지 않고 페이지숫자 div들의 사이즈로 조정, (반응형: 데탑사이즈 역시 조금 더 커지게 조정)

### 테스트 결과
- 검색결과 없는 페이지일 경우,  모바일, 태블릿, 데스크탑 모두 1페이지만 뜨도록 함
